### PR TITLE
Prevent "No such spy" trying to skills train level 0 spy

### DIFF
--- a/lib/Lacuna/DB/Result/Building/IntelTraining.pm
+++ b/lib/Lacuna/DB/Result/Building/IntelTraining.pm
@@ -136,8 +136,8 @@ sub train_spy {
     my ($self, $spy_id, $time_to_train) = @_;
     my $empire = $self->body->empire;
     my $spy = $self->get_spy($spy_id);
-    unless ($time_to_train) {
-        $time_to_train = $self->training_costs($spy)->{time};
+    unless (defined $time_to_train) {
+        $time_to_train = $self->training_costs($spy_id)->{time};
     }
     unless ($spy->task ~~ ['Counter Espionage','Idle']) {
         confess [1011, 'Spy must be idle to train.'];

--- a/lib/Lacuna/DB/Result/Building/MayhemTraining.pm
+++ b/lib/Lacuna/DB/Result/Building/MayhemTraining.pm
@@ -139,8 +139,8 @@ sub train_spy {
     my ($self, $spy_id, $time_to_train) = @_;
     my $empire = $self->body->empire;
     my $spy = $self->get_spy($spy_id);
-    unless ($time_to_train) {
-        $time_to_train = $self->training_costs($spy)->{time};
+    unless (defined $time_to_train) {
+        $time_to_train = $self->training_costs($spy_id)->{time};
     }
     unless ($spy->task ~~ ['Counter Espionage','Idle']) {
         confess [1011, 'Spy must be idle to train.'];

--- a/lib/Lacuna/DB/Result/Building/PoliticsTraining.pm
+++ b/lib/Lacuna/DB/Result/Building/PoliticsTraining.pm
@@ -136,8 +136,8 @@ sub train_spy {
     my ($self, $spy_id, $time_to_train) = @_;
     my $empire = $self->body->empire;
     my $spy = $self->get_spy($spy_id);
-    unless ($time_to_train) {
-        $time_to_train = $self->training_costs($spy)->{time};
+    unless (defined $time_to_train) {
+        $time_to_train = $self->training_costs($spy_id)->{time};
     }
     unless ($spy->task ~~ ['Counter Espionage','Idle']) {
         confess [1011, 'Spy must be idle to train.'];

--- a/lib/Lacuna/DB/Result/Building/TheftTraining.pm
+++ b/lib/Lacuna/DB/Result/Building/TheftTraining.pm
@@ -136,8 +136,8 @@ sub train_spy {
     my ($self, $spy_id, $time_to_train) = @_;
     my $empire = $self->body->empire;
     my $spy = $self->get_spy($spy_id);
-    unless ($time_to_train) {
-        $time_to_train = $self->training_costs($spy)->{time};
+    unless (defined $time_to_train) {
+        $time_to_train = $self->training_costs($spy_id)->{time};
     }
     unless ($spy->task ~~ ['Counter Espionage','Idle']) {
         confess [1011, 'Spy must be idle to train.'];


### PR DESCRIPTION
Arguably a level 0 spy shouldn't have a 0 training time in the first place...
