### PR TITLE
insurrection: don't leave working shipyard but no ships building

### DIFF
--- a/lib/Lacuna/DB/Result/Spies.pm
+++ b/lib/Lacuna/DB/Result/Spies.pm
@@ -1457,7 +1457,7 @@ sub steal_planet {
 
     my $ships = Lacuna->db->resultset('Lacuna::DB::Result::Ships')
                       ->search({body_id => $self->on_body_id,
-                                task => { '!=' => 'Docked' } });
+                                task => { not_in => ['Docked','Building'] } });
     while (my $ship = $ships->next) {
       next if ($ship->task eq 'Waste Chain');
       if ($ship->task eq 'Waiting On Trade') {

--- a/var/www/public/changes.txt
+++ b/var/www/public/changes.txt
@@ -1,3 +1,5 @@
+ - Fix: Insurrected planet will keep ships building
+
 3.0870:
  - Add: Black Hole Generator can now be subsidized both for accuracy and cooldown
  - Fix: List of stars to rename in Parliament are now sorted


### PR DESCRIPTION
Re: http://community.lacunaexpanse.com/forums/support/buildings-busy-after-insurrection/3

Or the ships could be deleted and the shipyard set to not working, but that seems too friendly :)
