### PR TITLE
Should be able to add SSLa/b/c/d to the build queue at the same time

### DIFF
--- a/lib/Lacuna/DB/Result/Building/SSLb.pm
+++ b/lib/Lacuna/DB/Result/Building/SSLb.pm
@@ -10,7 +10,7 @@ around 'build_tags' => sub {
     return ($orig->($class), qw(Construction Ships));
 };
 
-use constant building_prereq => {'Lacuna::DB::Result::Building::SSLa'=>1};
+use constant building_prereq => {'Lacuna::DB::Result::Building::SSLa'=>0};
 use constant max_instances_per_planet => 1;
 
 use constant controller_class => 'Lacuna::RPC::Building::SSLb';

--- a/lib/Lacuna/DB/Result/Building/SSLc.pm
+++ b/lib/Lacuna/DB/Result/Building/SSLc.pm
@@ -10,7 +10,7 @@ around 'build_tags' => sub {
     return ($orig->($class), qw(Construction Ships));
 };
 
-use constant building_prereq => {'Lacuna::DB::Result::Building::SSLb'=>1};
+use constant building_prereq => {'Lacuna::DB::Result::Building::SSLb'=>0};
 use constant max_instances_per_planet => 1;
 
 use constant controller_class => 'Lacuna::RPC::Building::SSLc';

--- a/lib/Lacuna/DB/Result/Building/SSLd.pm
+++ b/lib/Lacuna/DB/Result/Building/SSLd.pm
@@ -10,7 +10,7 @@ around 'build_tags' => sub {
     return ($orig->($class), qw(Construction Ships));
 };
 
-use constant building_prereq => {'Lacuna::DB::Result::Building::SSLc'=>1};
+use constant building_prereq => {'Lacuna::DB::Result::Building::SSLc'=>0};
 use constant max_instances_per_planet => 1;
 
 use constant controller_class => 'Lacuna::RPC::Building::SSLd';


### PR DESCRIPTION
Should be able to put SSLb (then c, d) in the build queue after SSLa even if SSLa has not finished building.  Set the prereq level to 0 (rather than 1).
