### PR TITLE
don't pass DateTime object to DBIC->search() - use storage formatter

### DIFF
--- a/lib/Lacuna/DB/Result/Building/Module/PoliceStation.pm
+++ b/lib/Lacuna/DB/Result/Building/Module/PoliceStation.pm
@@ -26,6 +26,10 @@ sub foreign_spies {
 
 sub prisoners {
     my $self = shift;
+
+    my $dt_parser = Lacuna->db->storage->datetime_parser;
+    my $now = $dt_parser->format_datetime( DateTime->now );
+
     return  Lacuna
         ->db
         ->resultset('Lacuna::DB::Result::Spies')
@@ -33,7 +37,7 @@ sub prisoners {
             {
                 on_body_id  => $self->body_id,
                 task        => { 'in' => [ 'Captured', 'Prisoner Transport' ] },
-                available_on=> { '>' => DateTime->now },
+                available_on=> { '>' => $now },
             }
         );
 }

--- a/lib/Lacuna/DB/Result/Building/Security.pm
+++ b/lib/Lacuna/DB/Result/Building/Security.pm
@@ -57,6 +57,10 @@ sub foreign_spies {
 
 sub prisoners {
     my $self = shift;
+
+    my $dt_parser = Lacuna->db->storage->datetime_parser;
+    my $now = $dt_parser->format_datetime( DateTime->now );
+
     return  Lacuna
         ->db
         ->resultset('Lacuna::DB::Result::Spies')
@@ -64,7 +68,7 @@ sub prisoners {
             {
                 on_body_id  => $self->body_id,
                 task        => { 'in' => [ 'Captured', 'Prisoner Transport' ] },
-                available_on=> { '>' => DateTime->now },
+                available_on=> { '>' => $now },
             }
         );
 }

--- a/lib/Lacuna/RPC/Building/SpacePort.pm
+++ b/lib/Lacuna/RPC/Building/SpacePort.pm
@@ -609,6 +609,9 @@ sub prepare_fetch_spies {
     while (my $ship = $ships->next) {
         push @ships, $ship->get_status($on_body);
     }
+
+    my $dt_parser = Lacuna->db->storage->datetime_parser;
+    my $now = $dt_parser->format_datetime( DateTime->now );
     
     my $spies = Lacuna->db->resultset('Lacuna::DB::Result::Spies')->search(
         {
@@ -618,7 +621,7 @@ sub prepare_fetch_spies {
                 task => { in => [ 'Idle', 'Counter Espionage' ], },
                 -and => [
                     task => { in => [ 'Unconscious', 'Debriefing' ], },
-                    available_on => { '<' => '\NOW()' }, 
+                    available_on => { '<' => $now }, 
                 ],
             ],
         },

--- a/lib/Lacuna/Role/TraderRpc.pm
+++ b/lib/Lacuna/Role/TraderRpc.pm
@@ -152,8 +152,11 @@ sub get_prisoners {
     my ($self, $session_id, $building_id) = @_;
     my $empire = $self->get_empire_by_session($session_id);
     my $building = $self->get_building($empire, $building_id);
+    my $dt_parser = Lacuna->db->storage->datetime_parser;
+    my $now = $dt_parser->format_datetime( DateTime->now );
+
     my $prisoners = Lacuna->db->resultset('Lacuna::DB::Result::Spies')->search(
-        { on_body_id => $building->body_id, task => 'Captured', available_on => { '>' => DateTime->now } },
+        { on_body_id => $building->body_id, task => 'Captured', available_on => { '>' => $now } },
         {order_by => [ 'name' ]}
         );
     my @out;

--- a/lib/Lacuna/Web/ApiKey.pm
+++ b/lib/Lacuna/Web/ApiKey.pm
@@ -18,7 +18,8 @@ sub www_view_stats {
     my $row = sub {
         return '<tr><td>'.$_[0].'</td><td>'.$_[1].'</td><td>'.$_[2].'</td></tr>';
     };
-    my $thirty_days_ago = DateTime->now->subtract(days=>30);
+    my $dt_parser = Lacuna->db->storage->datetime_parser;
+    my $thirty_days_ago = $dt_parser->format_datetime( DateTime->now->subtract(days=>30) );
     my $out = "<h1>Stats for $name</h1><table style=\"width: 100%;\"><tr><th>Statistic</th><th>Past 30 Days</th><th>All Time</th></tr>";
     my $login = Lacuna->db->resultset('Lacuna::DB::Result::Log::Login')->search({api_key => $pair->public_key});
     $out .= $row->('Empires Using',

--- a/lib/Lacuna/Web/MissionCurator.pm
+++ b/lib/Lacuna/Web/MissionCurator.pm
@@ -34,7 +34,9 @@ sub www_add_essentia {
         body    => 'I have approved a mission pack for '.$empire->name.'.',
         tags    => ['Mission','Correspondence'],
     );
-    my $recent = Lacuna->db->resultset('Lacuna::DB::Result::Log::Essentia')->search({ empire_id => $curator->id, description => 'Mission Curator', date_stamp => { '>' => DateTime->now->subtract(days => 7)}})->count;
+    my $dt_parser = Lacuna->db->storage->datetime_parser;
+    my $seven_days_ago = $dt_parser->format_datetime( DateTime->now->subtract(days => 7) );
+    my $recent = Lacuna->db->resultset('Lacuna::DB::Result::Log::Essentia')->search({ empire_id => $curator->id, description => 'Mission Curator', date_stamp => { '>' => $seven_days_ago}})->count;
     $curator->add_essentia(100, 'Mission Curator')->update unless $recent;
     return $self->www_default($request, 'Essentia Added');
 }


### PR DESCRIPTION
This could be the source of seemingly-random bugs with ships, trades and prisoners
