### PR TITLE
When removing a chain, the target needs recalc or it will continue to

### DIFF
--- a/lib/Lacuna/RPC/Building/Trade.pm
+++ b/lib/Lacuna/RPC/Building/Trade.pm
@@ -254,7 +254,10 @@ sub delete_supply_chain {
 
     my $chain = Lacuna->db->resultset('Lacuna::DB::Result::SupplyChain')->find($supply_chain_id);
     if ($chain) {
+        my $target = $chain->target;
         $building->remove_supply_chain($chain);
+        $target->needs_recalc(1);
+        $target->update;
     }
     return $self->view_supply_chains($session_id, $building_id);    
 }


### PR DESCRIPTION
think it's receiving that resource.  Add in a needs_recalc for the target.
