### PR TITLE
Intelligence.pod docs updates

### DIFF
--- a/docs/Intelligence.pod
+++ b/docs/Intelligence.pod
@@ -137,15 +137,11 @@ The unique id of your Intelligence Ministry.
 
 =head3 page_number
 
-Defaults to 1. An integer representing which page to view. Shows 25 spies per page.
+Defaults to 1. An integer representing which page to view. Shows 30 spies per page.
 
 =head2 view_all_spies ( session_id, building_id )
 
 Returns the list of spies you have on your roster from that Intelligence Ministy. Otherwise identical to view_spies.
-
-=head2 view_empire_spies ( session_id, building_id )
-
-Returns the list of spies you have on your roster from your empire. Otherwise identical to view_spies.
 
 =head2 subsidize_training ( session_id, building_id )
 


### PR DESCRIPTION
view_spies() returns 30 spies per page, not 25 as currently documented.
view_empire_spies() no longer exists at all; documentation removed.
