### PR TITLE
When trying to deploy on non-linode systems, there are a few issues.

### DIFF
--- a/bin/setup/generate_captcha.pl
+++ b/bin/setup/generate_captcha.pl
@@ -7,6 +7,7 @@ use UUID::Tiny ':std';
 use File::Path qw(remove_tree make_path);
 
 my $db = Lacuna->db;
+my $config = Lacuna->config;
 my $captchas = $db->resultset('Lacuna::DB::Result::Captcha');
 
 say "Generating Riddles";
@@ -125,7 +126,7 @@ make_path('/data/captcha');
 say "Generating Captchas...";
 my $counter = 0;
 foreach my $riddle (keys %riddles) {
-    foreach my $font (qw(Ayuthaya Chalkduster HeadlineA Kai)) {
+    foreach my $font (@{ $config->get('captcha/fonts') || [ "Ayuthaya", "Chalkduster", "HeadlineA", "Kai" ] }) {
         foreach my $style (qw(default rect circle ellipse ec blank)) {
             foreach my $bg_color (qw(#666600 #660066 #006666)) {
                 foreach my $fg_color (qw(#ddffff #ffddff #ffffdd)) {
@@ -134,7 +135,7 @@ foreach my $riddle (keys %riddles) {
                             width   => 300,
                             height  => 80,
                             lines   => 20,
-                            font    => '/Library/Fonts/'.$font.'.ttf',
+                            font    => ($config->get('captcha/fontpath')||"/Library/Fonts").'/'.$font.'.ttf',
                             bgcolor => $bg_color,
                             ptsize  => 32,
                             rndmax  => 3,

--- a/etc/lacuna.conf.template
+++ b/etc/lacuna.conf.template
@@ -8,6 +8,21 @@
         "recovery" : 0,
         "side_chance" : 0,
     },
+   "beanstalk" : {
+      "debug" : 0,
+      "server" : "localhost",
+      "ttr" : 120,
+      "max_timeouts" : 10,
+      "max_reserves" : 10
+   },
+   "captcha" : {
+      # path to the fonts being used.
+      "fontpath" : "/Library/Fonts",
+      # .ttf fonts in above path
+      "fonts" : [ "Ayuthaya", "Chalkduster", "HeadlineA", "Kai" ],
+      # this is 16416 x number of fonts
+      "total" : 65664
+   },
    "db" : {
       "dsn" : "DBI:mysql:XXXX",
       "password" : "XXXX",

--- a/lib/Lacuna/DB/Result/Building/Shipyard.pm
+++ b/lib/Lacuna/DB/Result/Building/Shipyard.pm
@@ -70,7 +70,7 @@ has max_ships => (
             class       => $self->class, 
             body_id     => $self->body_id,
             efficiency  => 100,
-        } )->get_column('level')->sum ++ 0;
+        } )->get_column('level')->sum + 0;
     },
 );
 

--- a/lib/Lacuna/DB/Result/Schedule.pm
+++ b/lib/Lacuna/DB/Result/Schedule.pm
@@ -26,7 +26,7 @@ __PACKAGE__->add_columns(
     parent_table => {data_type => 'varchar', size => 30, is_nullable => 0},
     parent_id    => {data_type => 'int', size => 11, is_nullable => 0},
     task         => {data_type => 'varchar', size => 30, is_nullable => 0},
-    args         => {data_type => 'medium_blob', is_nullable => 1, serializer_class => 'JSON'},
+    args         => {data_type => 'mediumblob', is_nullable => 1, serializer_class => 'JSON'},
 );
 
 after 'insert' => sub {

--- a/lib/Lacuna/RPC/Captcha.pm
+++ b/lib/Lacuna/RPC/Captcha.pm
@@ -9,7 +9,7 @@ use DateTime;
 
 sub fetch {
     my ($self, $session_id) = @_;
-    my $captcha = Lacuna->db->resultset('Lacuna::DB::Result::Captcha')->find(randint(1,65664));
+    my $captcha = Lacuna->db->resultset('Lacuna::DB::Result::Captcha')->find(randint(1,Lacuna->config->get('captcha/total')||65664));
     Lacuna->cache->set('captcha', $session_id, { guid => $captcha->guid, solution => $captcha->solution }, 60 * 30 );
 	Lacuna->cache->delete('captcha_valid', $session_id);
     return {

--- a/lib/Lacuna/RPC/Empire.pm
+++ b/lib/Lacuna/RPC/Empire.pm
@@ -157,7 +157,7 @@ sub benchmark {
 sub fetch_captcha {
     my ($self, $plack_request) = @_;
     my $ip = $plack_request->address;
-    my $captcha = Lacuna->db->resultset('Lacuna::DB::Result::Captcha')->find(randint(1,65664));
+    my $captcha = Lacuna->db->resultset('Lacuna::DB::Result::Captcha')->find(randint(1,Lacuna->config->get('captcha/total')));
     Lacuna->cache->set('create_empire_captcha', $ip, { guid => $captcha->guid, solution => $captcha->solution }, 60 * 15 );
     return {
         guid    => $captcha->guid,


### PR DESCRIPTION
1. The font location, names, and even number, can change.  Put this
   into the lacuna.conf.template, but default to linode's values.
2. Setting up beanstalk - we can put this right into the template
   (and can be commented out if not needed, like much of the rest of the
   template)
3. A few errors during execution: medium_blob won't deploy, and a ++ found
   somewhere.

With all of this, I can get a running system up a fair bit faster,
though some documentation on the captcha bit is likely required.
