### PR TITLE
If beanstalk has garbage in it, robustly ignore it.

### DIFF
--- a/bin/schedule_building.pl
+++ b/bin/schedule_building.pl
@@ -136,9 +136,10 @@ eval {
     local $SIG{ALRM} = sub { die "alarm\n" };
     alarm $timeout;
     
-    do {
+    LOOP: do {
         my $job     = $queue->consume('default');
         my $args    = $job->args;
+        $job->delete, next unless ref $args eq 'HASH';
         my $task    = $args->{task};
         my $task_args = $args->{args};
     

--- a/bin/schedule_ship_arrival.pl
+++ b/bin/schedule_ship_arrival.pl
@@ -112,9 +112,10 @@ eval {
     local $SIG{ALRM} = sub { die "alarm\n" };
     alarm $timeout;
     
-    do {
+    LOOP: do {
         my $job     = $queue->consume('arrive_queue');
         my $args    = $job->args;
+        $job->delete, next unless ref $args eq 'HASH';
         my $task    = $args->{task};
         my $task_args = $args->{args};
     


### PR DESCRIPTION
This can creep in while testing beanstalk.  Because the extra data was left in the queue, the scheduler would die each time without having cleared anything out and no diagnostics.  I suggest consuming and discarding the garbage and continuing.
