### PR TITLE
Comma-fy the scow waste.

### DIFF
--- a/lib/Lacuna/DB/Result/Ships.pm
+++ b/lib/Lacuna/DB/Result/Ships.pm
@@ -546,6 +546,7 @@ sub travel_time {
     $speed ||= 1;
     my $hours = $distance / $speed;
     my $seconds = 60 * 60 * $hours;
+    $seconds = 1 if $seconds < 1;
     return sprintf('%.0f', $seconds);
 }
 

--- a/lib/Lacuna/Role/Ship/Arrive/DumpWaste.pm
+++ b/lib/Lacuna/Role/Ship/Arrive/DumpWaste.pm
@@ -2,6 +2,7 @@ package Lacuna::Role::Ship::Arrive::DumpWaste;
 
 use strict;
 use Moose::Role;
+use Lacuna::Util qw(commify);
 
 after handle_arrival_procedures => sub {
     my ($self) = @_;
@@ -30,12 +31,13 @@ after handle_arrival_procedures => sub {
     }
     $body_attacked->add_waste($waste_dumped);
     $body_attacked->update;
+    $waste_dumped = commify($waste_dumped); # commify so emails look nicer
 
     unless ($self->body->empire->skip_attack_messages) {
         $self->body->empire->send_predefined_message(
             tags        => ['Attack','Alert'],
             filename    => 'our_scow_hit.txt',
-            params      => [$body_attacked->x, $body_attacked->y, $body_attacked->name, $self->hold_size],
+            params      => [$body_attacked->x, $body_attacked->y, $body_attacked->name, $waste_dumped],
         );
     }
 
@@ -43,7 +45,7 @@ after handle_arrival_procedures => sub {
         $body_attacked->empire->send_predefined_message(
             tags        => ['Attack','Alert'],
             filename    => 'hit_by_scow.txt',
-            params      => [$self->body->empire_id, $self->body->empire->name, $body_attacked->id, $body_attacked->name, $self->hold_size],
+            params      => [$self->body->empire_id, $self->body->empire->name, $body_attacked->id, $body_attacked->name, $waste_dumped],
         );
     }
 


### PR DESCRIPTION
Found out that when a ship is sent to itself, the after method modifier
for send doesn't trigger - beanstalk processes it too fast.  Introduce a
minimum 1-second timer for sending ships, that way the after method modifier
can trigger, setting the payload, before the beanstalk process picks it up.
