### PR TITLE
Improve unsustainable message to hopefully make it clearer.

### DIFF
--- a/lib/Lacuna/DB/Result/Map/Body/Planet.pm
+++ b/lib/Lacuna/DB/Result/Map/Body/Planet.pm
@@ -875,7 +875,7 @@ sub has_resources_to_operate {
         if ($delta < 0 && $future->{$method} + $delta < 0) {
             my $resource = $method;
             $resource =~ s/(\w+)_hour/$1/;
-            confess [1012, "Unsustainable. Not enough resources being produced to build this.", $resource];
+            confess [1012, "Unsustainable given the current and planned resource consumption. Not enough resources being produced to build this.", $resource];
         }
     }
     return 1;


### PR DESCRIPTION
After a brief conversation in Help chat, where Draeician was confused as to why s/he couldn't update their SSL, it was determined that it was due to stuff already in the build queue.  Suggestion is to improve the message to make it more clear as to possible causes.
