### PR TITLE
Move pod timer to a PCC "build", with varying timer based on the PCC level.

### DIFF
--- a/docs/PlanetaryCommand.pod
+++ b/docs/PlanetaryCommand.pod
@@ -131,5 +131,19 @@ A session id.
 
 The unique id of the PCC.
 
+=head2 subsidize_pod_cooldown ( session_id, building_id )
+
+Will spend 2 essentia to allow a new pod to be sent immediately. Returns C<view>.
+
+Throws 1011.
+
+=head3 session_id
+
+A session id.
+
+=head3 building_id
+
+The unique id of the Planetary Command Center.
+
 
 =cut

--- a/lib/Lacuna/DB/Result/Building/PlanetaryCommand.pm
+++ b/lib/Lacuna/DB/Result/Building/PlanetaryCommand.pm
@@ -71,6 +71,25 @@ sub incoming_supply_chains {
     return Lacuna->db->resultset('Lacuna::DB::Result::SupplyChain')->search({ target_id => $self->body_id });
 }
 
+sub sent_a_pod
+{
+    my ($self) = @_;
+
+    my $level    = $self->level;
+    my $cooldown = int(
+                         28.747 * $level * $level
+                       - 2877.4 * $level
+                       + 89249.
+                      );
+
+    $self->start_work({}, $cooldown);
+}
+
+sub can_send_pod
+{
+    my ($self) = @_;
+    ! $self->is_working;
+}
 
 no Moose;
 __PACKAGE__->meta->make_immutable(inline_constructor => 0);

--- a/lib/Lacuna/RPC/Building/PlanetaryCommand.pm
+++ b/lib/Lacuna/RPC/Building/PlanetaryCommand.pm
@@ -54,7 +54,34 @@ sub view_plans {
     }
 }
 
-__PACKAGE__->register_rpc_method_names(qw(view_plans view_incoming_supply_chains));
+sub subsidise_pod_cooldown {
+    my ($self, $session_id, $building_id) = @_;
+    my $empire = $self->get_empire_by_session($session_id);
+    my $building = $self->get_building($empire, $building_id);
+
+    unless ($building->is_working) {
+        confess [1010, "PCC is not in cooldown mode."];
+    }
+
+    unless ($empire->essentia >= 2) {
+        confess [1011, "Not enough essentia."];
+    }
+
+    $building->finish_work->update;
+    $empire->spend_essentia({
+        amount  => 2,
+        reason  => 'PCC cooldown subsidy after the fact',
+    });
+    $empire->update;
+
+    return $self->view($empire, $building);
+}
+
+__PACKAGE__->register_rpc_method_names(qw(
+    subsidise_pod_cooldown
+    view_plans
+    view_incoming_supply_chains
+));
 
 
 

--- a/lib/Lacuna/Role/Ship/Send/LoadSupplyPod.pm
+++ b/lib/Lacuna/Role/Ship/Send/LoadSupplyPod.pm
@@ -78,13 +78,14 @@ after send => sub {
     $self->payload($payload);
     $self->update;
     $body->update;
-    Lacuna->cache->set('supply_pod_sent',$self->body_id,1,60*60*24);
+
+    $self->body->get_a_building("PlanetaryCommand")->sent_a_pod;
 };
 
 after can_send_to_target => sub {
     my ($self, $target) = @_;
-    confess [1010, 'Cannot send more than one per day per planet.']
-      if (Lacuna->cache->get('supply_pod_sent',$self->body_id));
+    confess [1010, 'Cannot send another supply pod so soon after sending previous supply pod.']
+      if $self->body->get_a_building("PlanetaryCommand")->can_send_pod;
 };
 
 1;


### PR DESCRIPTION
A higher level PCC can send supply pods more often than a low level PCC.
Starts at 24 hours for level 1, 12 hours for level 20, and 8 hours for
level 30, with a reasonably-smooth progression between them.

Added a subsidize_pod_cooldown RPC to allow immediate resending of a pod
for 2e.

Partial resolution for issue #298 - UI change still required
