### PR TITLE
Intel min and send-spy (spaceport) should use the same ordering for spy lists

### DIFF
--- a/lib/Lacuna/RPC/Building/Intelligence.pm
+++ b/lib/Lacuna/RPC/Building/Intelligence.pm
@@ -27,6 +27,7 @@ sub view_spies {
                                                     rows => 30,
                                                     page => $page_number,
                                                     # match the order_by in L::RPC::B::SpacePort::prepare_send_spies
+                                                    # and in L::RPC::B::MercinariesGuild::get_spies
                                                     order_by => {
                                                         -asc => [ qw/name id/ ]
                                                     }

--- a/lib/Lacuna/RPC/Building/MercenariesGuild.pm
+++ b/lib/Lacuna/RPC/Building/MercenariesGuild.pm
@@ -220,7 +220,12 @@ sub get_spies {
     my $building = $self->get_building($empire, $building_id);
     my $spies = Lacuna->db->resultset('Lacuna::DB::Result::Spies')->search(
         { empire_id => $empire->id, on_body_id => $building->body_id, task => { in => ['Counter Espionage','Idle'] } },
-        { order_by => 'name' }
+        {
+            # match the order_by in L::RPC::B::Intelligence::view_spies
+            order_by => {
+                -asc => [ qw/name id/ ],
+            }
+        },
     );
     my @out;
     while (my $spy = $spies->next) {

--- a/lib/Lacuna/RPC/Building/SpacePort.pm
+++ b/lib/Lacuna/RPC/Building/SpacePort.pm
@@ -510,7 +510,7 @@ sub prepare_send_spies {
                 ],
             ],
         },
-        { 
+        {
             # match the order_by in L::RPC::B::Intelligence::view_spies
             order_by => {
                 -asc => [ qw/name id/ ],


### PR DESCRIPTION
making it easier to find spies in both.  The previous ordering
for the spaceport would not be guaranteed to be the same order from run
to run amongst spies with the same name, whereas the intel min had an
unguaranteed order regardless, which could be an issue in theory going
from page to page.  The new order will be based on name with secondary sorting
based on id, allowing the player full control over the spy ordering, or,
failing that (because the player doesn't give any names), at least a
predictable FIFO ordering.
