### PR TITLE
Adjust Arch Min search time from 6 hours to 5:50 so four user searches c...

### DIFF
--- a/lib/Lacuna/DB/Result/Building/Archaeology.pm
+++ b/lib/Lacuna/DB/Result/Building/Archaeology.pm
@@ -640,7 +640,7 @@ sub search_for_glyph {
     $body->update;
     $self->start_work({
         ore_type    => $ore,
-    }, 60*60*6)->update;
+    }, 60*60*6 - 600 )->update;
 }
 
 before finish_work => sub {


### PR DESCRIPTION
...an be performed in a day.

I believe that the initial reason for a search taking 6 hours was so that 4 searches could be performed in a day.  But what actually happens if you schedule your arch min searcher to run every six hours is that it will periodically run into an archmin that's still working (with only a few seconds left on the job, but working).

Trying to account for those few seconds on the user's side will result in longer and longer sleeps, and still ends up performing fewer than 4 searches per day.

By changing the actual building work time to 5 hours, 50 minutes, a scheduled search script can be run every 6 hours with a reasonable expectation of actually being able to search every 6 hours.