### PR TITLE
Clean things out in deploy script

### DIFF
--- a/bin/deploy.pl
+++ b/bin/deploy.pl
@@ -106,7 +106,7 @@ END_TEXT
                 system("node_modules/bower/bin/bower","install","--config.interactive=false","--allow-root")
                     if -e "node_modules/bower/bin/bower";
                 system("gulp clean");
-                system("gulp build");
+                system("gulp");
 
                 my $lacuna_dir = $dir->subdir('lacuna');
                 $lacuna_dir->recurse(

--- a/bin/deploy.pl
+++ b/bin/deploy.pl
@@ -101,10 +101,12 @@ END_TEXT
             {
                 # new gulp-based client.
                 chdir($repo_config->{path});
+                system("npm prune");
                 system("npm install");
                 system("node_modules/bower/bin/bower","install","--config.interactive=false","--allow-root")
                     if -e "node_modules/bower/bin/bower";
-                system("gulp");
+                system("gulp clean");
+                system("gulp build");
 
                 my $lacuna_dir = $dir->subdir('lacuna');
                 $lacuna_dir->recurse(


### PR DESCRIPTION
`npm prune` clears out node modules that are not specified in the `package.json` file. `gulp clean` removes all build files.